### PR TITLE
known-amendments: fix drop size scientific notation

### DIFF
--- a/content/resources/known-amendments.md
+++ b/content/resources/known-amendments.md
@@ -780,7 +780,7 @@ In general, offers can be _reduced_ in 3 ways:
 - The offer can be partially consumed after being placed into an order book.
 - The offer can be under-funded, meaning its owner has less funds than it specifies.
 
-With this amendment, the exchange rate of a reduced offer is rounded such that it is as good or better than the original offer (from the taker's perspective). This allows the reduced offer to be consumed by offers that would have matched the original, full amounts. The rounded amount is no more than 1 drop of XRP or 1e-81 of a token.
+With this amendment, the exchange rate of a reduced offer is rounded such that it is as good or better than the original offer (from the taker's perspective). This allows the reduced offer to be consumed by offers that would have matched the original, full amounts. The rounded amount is no more than 1 drop of XRP or 1e+8 of a token.
 
 Without this amendment, an offer with very small amounts remaining can have a a much worse exchange rate after rounding than it had initially. This can cause an offer for very small amounts to "block" better offers in the same order book from being taken.
 


### PR DESCRIPTION
Applied correction to known-amendments doc where scientific notation of a drop size was incorrectly displayed as 1e-81 when it should be 1e+8.